### PR TITLE
Update Mac-OS credential file path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ This action takes the following inputs:
 - `creditionals`: Uses this account creditionals to publish
   You must be logged in to pub.dev to find this `creditional.json` file under
 
-  | Platform  | path                                                                                  |
-  | --------- | ------------------------------------------------------------------------------------- |
-  | `Windows` | `%LOCALAPPDATA%\Pub\Cache\credentials.json` or `%APPDATA%\Pub\Cache\credentials.json` |
-  | `Linux`   | `~/.pub-cache/credentials.json`                                                       |
-  | `Mac-OS`  | `~/.pub-cache/credentials.json`                                                       |
+  | Platform  | path                                                                                         |
+  | --------- | -------------------------------------------------------------------------------------------- |
+  | `Windows` | `%LOCALAPPDATA%\Pub\Cache\credentials.json` or `%APPDATA%\Pub\Cache\credentials.json`        |
+  | `Linux`   | `~/.pub-cache/credentials.json`                                                              |
+  | `Mac-OS`  | `~/.pub-cache/credentials.json` or `~/Library/Application Support/dart/pub-credentials.json`|                                                 
 
   copy the contents of this file and use [GitHub secret](https://docs.github.com/en/actions/reference/encrypted-secrets) to access it in you work flow.
   *If this file doesn't exist try `dart pub logout && dart pub login`.*


### PR DESCRIPTION
The location of the credentials file on `OSX` has changed. The new location is `~/Library/Application Support/dart/pub-credentials.json` since not everyone might be on the same `dart` version, I've listed both locations as was done for `Windows`.